### PR TITLE
Issues #194, #196

### DIFF
--- a/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
@@ -62,4 +62,13 @@ object TaskGatherUnorderedSuite extends BaseTestSuite {
     s.tick(1.second)
     assertEquals(f.value, None)
   }
+
+  test("Task.gatherUnordered should be stack-safe") { implicit s =>
+    val count = 10000
+    val tasks = (0 until count).map(x => Task.evalAlways(x))
+    val sum = Task.gatherUnordered(tasks).map(_.sum)
+
+    val result = sum.runAsync; s.tick()
+    assertEquals(result.value.get, Success(count * (count-1) / 2))
+  }
 }

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskMapBothSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.eval
+
+import scala.util.Success
+
+object TaskMapBothSuite extends BaseTestSuite {
+  test("sum two async tasks") { implicit s =>
+    val ta = Task(1)
+    val tb = Task(2)
+
+    val r = Task.mapBoth(ta, tb)(_ + _)
+    val f = r.runAsync; s.tick()
+    assertEquals(f.value.get, Success(3))
+  }
+
+  test("sum two synchronous tasks") { implicit s =>
+    val ta = Task.evalAlways(1)
+    val tb = Task.evalAlways(2)
+
+    val r = Task.mapBoth(ta, tb)(_ + _)
+    val f = r.runAsync; s.tick()
+    assertEquals(f.value.get, Success(3))
+  }
+
+  test("should be stack-safe for synchronous tasks") { implicit s =>
+    val count = 10000
+    val tasks = (0 until count).map(x => Task.evalAlways(x))
+    val init = Task.evalAlways(0L)
+
+    val sum = tasks.foldLeft(init)((acc,t) => Task.mapBoth(acc, t)(_ + _))
+    val result = sum.runAsync
+
+    s.tick()
+    assertEquals(result.value.get, Success(count * (count-1) / 2))
+  }
+
+  test("should be stack-safe for asynchronous tasks") { implicit s =>
+    val count = 10000
+    val tasks = (0 until count).map(x => Task(x))
+    val init = Task.evalAlways(0L)
+
+    val sum = tasks.foldLeft(init)((acc,t) => Task.mapBoth(acc, t)(_ + _))
+    val result = sum.runAsync
+
+    s.tick()
+    assertEquals(result.value.get, Success(count * (count-1) / 2))
+  }
+
+  test("sum random synchronous tasks") { implicit s =>
+    check1 { (numbers: List[Int]) =>
+      val sum = numbers.foldLeft(Task.now(0))((acc,t) => Task.mapBoth(acc, Task.evalAlways(t))(_+_))
+      sum === Task.now(numbers.sum)
+    }
+  }
+
+  test("sum random asynchronous tasks") { implicit s =>
+    check1 { (numbers: List[Int]) =>
+      val sum = numbers.foldLeft(Task(0))((acc,t) => Task.mapBoth(acc, Task(t))(_+_))
+      sum === Task(numbers.sum)
+    }
+  }
+}

--- a/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/Observable.scala
@@ -118,11 +118,11 @@ trait Observable[+A] extends ObservableLike[A, Observable] { self =>
   def subscribe(nextFn: A => Future[Ack])(implicit s: Scheduler): Cancelable =
     subscribe(nextFn, error => s.reportFailure(error), () => ())
 
-  /** On execution, consumes the source observable with the
-    * given [[Consumer]], effectively transforming the source observable
-    * into a [[monix.eval.Task Task]].
+  /** On execution, consumes the source observable
+    * with the given [[Consumer]], effectively transforming the
+    * source observable into a [[monix.eval.Task Task]].
     */
-  def runWith[R](f: Consumer[A, R]): Task[R] =
+  def runWith[R](f: Consumer[A,R]): Task[R] =
     f(self)
 
   /** Transforms the source using the given operator. */


### PR DESCRIPTION
- Fixes issue #194 for - `Task.mapBoth` is not stack-safe.
- Issue #196 - Includes [Consumer.create](https://monix.io/docs/2x/reactive/consumer.html#consumercreate) because it was described in the documentation and was on my master