### PR TITLE
Execute an Action (() => Unit)

### DIFF
--- a/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
@@ -152,8 +152,8 @@ object Scheduler extends SchedulerCompanionImpl {
   /** Utilities complementing the `Scheduler` interface. */
   implicit final class Extensions(val source: Scheduler) extends AnyVal {
     /** Schedules the given `action` for immediate execution. */
-    def execute(action: => Unit): Unit =
-      source.execute(RunnableAction(action))
+    def executeNow(f: => Unit): Unit =
+      source.execute(RunnableAction.from(f _))
 
     /** Schedules a task to run in the future, after `initialDelay`.
       *

--- a/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/Scheduler.scala
@@ -151,6 +151,10 @@ object Scheduler extends SchedulerCompanionImpl {
 
   /** Utilities complementing the `Scheduler` interface. */
   implicit final class Extensions(val source: Scheduler) extends AnyVal {
+    /** Schedules the given `action` for immediate execution. */
+    def execute(action: => Unit): Unit =
+      source.execute(RunnableAction(action))
+
     /** Schedules a task to run in the future, after `initialDelay`.
       *
       * For example the following schedules a message to be printed to

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/RunnableAction.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/RunnableAction.scala
@@ -18,15 +18,19 @@
 package monix.execution.internal
 
 /** Helper for converting any expression into a runnable */
-private[monix] final class RunnableAction private (action: => Unit)
+private[monix] final class RunnableAction private (action: () => Unit)
   extends Runnable {
 
   override def run(): Unit =
-    action
+    action()
 }
 
 private[monix] object RunnableAction {
   /** Builder for [[RunnableAction]] */
   def apply(action: => Unit): Runnable =
-    new RunnableAction(action)
+    new RunnableAction(action _)
+
+  /** Builder for [[RunnableAction]] */
+  def from(f: () => Unit): Runnable =
+    new RunnableAction(f)
 }

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/TestSchedulerSuite.scala
@@ -207,6 +207,15 @@ object TestSchedulerSuite extends TestSuite[TestScheduler] {
     assertEquals(seq.sum, expected.sum)
   }
 
+  test("execute extension method") { implicit s =>
+    var wasExecuted = false
+    s.executeNow { wasExecuted = true }
+
+    assert(!wasExecuted, "should not be executed yet")
+    s.tick()
+    assert(wasExecuted, "was executed")
+  }
+
   def action(f: => Unit): Runnable =
     new Runnable { def run() = f }
 


### PR DESCRIPTION
Added an execute overload which takes an Action (() => Unit), wraps it in RunnableAction and forwards it to the default execute method.