### PR TITLE
Fix and optimize gatherUnordered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ notifications:
 env:
   global:
     - MAIN_SCALA_VERSION=2.11.8
-    - PUBLISHER_REFERENCE_GC_TIMEOUT_MILLIS=900
+    - PUBLISHER_REFERENCE_GC_TIMEOUT_MILLIS=2000
 
 script:
   - project/travis-build.sh
@@ -26,7 +26,7 @@ before_install:
   - pip install --user codecov
 after_success:
   - project/travis-post-build.sh
-    
+
 cache:
   directories:
   - $HOME/.sbt/0.13

--- a/benchmarks/src/main/scala/monix/TaskGatherBenchmark.scala
+++ b/benchmarks/src/main/scala/monix/TaskGatherBenchmark.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2014-2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix
+
+import java.util.concurrent.TimeUnit
+
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.openjdk.jmh.annotations._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/*
+ * Sample run:
+ *
+ *     sbt "benchmarks/jmh:run -i 10 -wi 10 -f 1 -t 1 monix.TaskGatherBenchmark"
+ *
+ * Which means "10 iterations" "5 warmup iterations" "1 fork" "1 thread".
+ * Please note that benchmarks should be usually executed at least in
+ * 10 iterations (as a rule of thumb), but more is better.
+ */
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class TaskGatherBenchmark {
+  @Benchmark
+  def sequenceA(): Long = {
+    val tasks = (0 until 10000).map(_ => Task(1)).toList
+    val f = Task.sequence(tasks).map(_.sum.toLong).runAsync
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def sequenceS(): Long = {
+    val tasks = (0 until 10000).map(_ => Task.evalAlways(1)).toList
+    val f = Task.sequence(tasks).map(_.sum.toLong).runAsync
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def gatherA(): Long = {
+    val tasks = (0 until 10000).map(_ => Task(1)).toList
+    val f = Task.gather(tasks).map(_.sum.toLong).runAsync
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def gatherS(): Long = {
+    val tasks = (0 until 10000).map(_ => Task.evalAlways(1)).toList
+    val f = Task.gather(tasks).map(_.sum.toLong).runAsync
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def unorderedA(): Long = {
+    val tasks = (0 until 10000).map(_ => Task(1)).toList
+    val f = Task.gatherUnordered(tasks).map(_.sum.toLong).runAsync
+    Await.result(f, Duration.Inf)
+  }
+
+  @Benchmark
+  def unorderedS(): Long = {
+    val tasks = (0 until 10000).map(_ => Task.evalAlways(1)).toList
+    val f = Task.gatherUnordered(tasks).map(_.sum.toLong).runAsync
+    Await.result(f, Duration.Inf)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -260,7 +260,9 @@ lazy val typesJS = project.in(file("monix-types/js"))
   .settings(scalaJSSettings)
 
 lazy val executionCommon = crossVersionSharedSources ++ Seq(
-  name := "monix-execution"
+  name := "monix-execution",
+  // https://github.com/sbt/sbt/issues/2654
+  incOptions := incOptions.value.withLogRecompileOnMacro(false)
 )
 
 lazy val executionJVM = project.in(file("monix-execution/jvm"))

--- a/monix-eval/shared/src/main/scala/monix/eval/Task.scala
+++ b/monix-eval/shared/src/main/scala/monix/eval/Task.scala
@@ -26,9 +26,11 @@ import monix.execution.{Cancelable, CancelableFuture, Scheduler}
 import monix.types.Evaluable
 import org.reactivestreams.Subscriber
 import monix.execution.atomic.{Atomic, AtomicAny}
+
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Future, Promise, TimeoutException}
 import scala.util.control.NonFatal
@@ -817,54 +819,99 @@ object Task extends TaskInstances {
     * can be more efficient than `gather`.
     */
   def gatherUnordered[A, M[X] <: TraversableOnce[X]](in: M[Task[A]])
-    (implicit cbf: CanBuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] =
-    Async { (scheduler, conn, finalCallback) =>
-      var remaining = 1
-      val builder = cbf(in)
-      val lock = new AnyRef
-      val isActive = Atomic(true)
+    (implicit cbf: CanBuildFrom[M[Task[A]], A, M[A]]): Task[M[A]] = {
 
-      val composite = CompositeCancelable()
-      conn.push(composite)
+    // We are using OOP for initializing this `OnFinish` callback because we
+    // need something to synchronize on and because it's better for making the
+    // state explicit (e.g. the builder, remaining, isActive vars)
+    Async(new OnFinish[M[A]] { self =>
+      // Aggregates all results into a buffer.
+      // MUST BE synchronized by `self`!
+      private[this] var builder = cbf(in)
 
-      val cursor = in.toIterator
+      // Keeps track of tasks remaining to be completed.
+      // Is initialized by 1 because of the logic - tasks can run synchronously,
+      // and we decrement this value whenever one finishes, so we must prevent
+      // zero values before the loop is done.
+      // MUST BE synchronized by `self`!
+      private[this] var remaining = 1
 
-      lock.synchronized {
-        while (cursor.hasNext && !composite.isCanceled) {
-          remaining += 1
-          val task = cursor.next()
-          val stacked = StackedCancelable()
-          composite += stacked
+      // If this variable is false, then a task ended in error.
+      // MUST BE synchronized by `self`!
+      private[this] var isActive = true
 
-          Task.unsafeStartNow(task, scheduler, stacked,
-            new Callback[A] {
-              def onSuccess(value: A): Unit =
-                lock.synchronized {
-                  builder += value
-                  remaining -= 1
-                  if (remaining == 0) {
-                    conn.pop()
-                    finalCallback.onSuccess(builder.result())
-                  }
-                }
-
-              def onError(ex: Throwable): Unit =
-                if (isActive.getAndSet(false)) {
-                  conn.pop().cancel()
-                  finalCallback.onError(ex)
-                } else {
-                  scheduler.reportFailure(ex)
-                }
-            })
-        }
+      // MUST BE synchronized by `self`!
+      // MUST NOT BE called if isActive == false!
+      private def maybeSignalFinal(
+        conn: StackedCancelable, finalCallback: Callback[M[A]]): Unit = {
 
         remaining -= 1
         if (remaining == 0) {
+          isActive = false
           conn.pop()
           finalCallback.onSuccess(builder.result())
+          builder = null // GC relief
         }
       }
-    }
+
+      def apply(scheduler: Scheduler, conn: StackedCancelable, finalCallback: Callback[M[A]]): Unit = {
+        self.synchronized {
+          // Represents the collection of cancelables for all started tasks
+          val composite = CompositeCancelable()
+          conn.push(composite)
+
+          // Collecting all cancelables in a buffer, because adding
+          // cancelables one by one in our `CompositeCancelable` is
+          // expensive, so we do it at the end
+          val allCancelables = ListBuffer.empty[StackedCancelable]
+          val cursor = in.toIterator
+
+          // The `isActive` check short-circuits the process in case
+          // we have a synchronous task that just completed in error
+          while (cursor.hasNext && isActive) {
+            remaining += 1
+            val task = cursor.next()
+            val stacked = StackedCancelable()
+            allCancelables += stacked
+
+            // NOTE: Can run synchronously (immediately), depending
+            // on the task's type. The user should `fork` to ensure async!
+            Task.unsafeStartNow(task, scheduler, stacked,
+              new Callback[A] {
+                def onSuccess(value: A): Unit =
+                  self.synchronized {
+                    if (isActive) {
+                      builder += value
+                      maybeSignalFinal(conn, finalCallback)
+                    }
+                  }
+
+                def onError(ex: Throwable): Unit =
+                  self.synchronized {
+                    if (isActive) {
+                      isActive = false
+                      // This should cancel our CompositeCancelable
+                      conn.pop().cancel()
+                      finalCallback.onError(ex)
+                      builder = null // GC relief
+                    } else {
+                      scheduler.reportFailure(ex)
+                    }
+                  }
+              })
+          }
+
+          // All tasks could have executed synchronously, so we might be
+          // finished already. If so, then trigger the final callback.
+          maybeSignalFinal(conn, finalCallback)
+
+          // Note that if an error happened, this should cancel all
+          // other active tasks.
+          composite ++= allCancelables
+        }
+      }
+    })
+  }
 
   /** Obtain results from both `a` and `b`, nondeterministically ordering
     * their effects.

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskChooseFirstOfSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskChooseFirstOfSuite.scala
@@ -353,13 +353,13 @@ object TaskChooseFirstOfSuite extends BaseTestSuite {
   }
 
   test("Task.chooseFirstOf should be stack safe") { implicit s =>
-    val count = 10000
+    val count = 100000
     val tasks = (0 until count).map(x => Task(x))
     val init = Task.never[Int]
 
     val sum = tasks.foldLeft(init)((acc,t) => Task.chooseFirstOf(acc,t).map {
-      case Left((a,fb)) => fb.cancel(); a
-      case Right((fa, b)) => fa.cancel(); b
+      case Left((a,fb)) => a
+      case Right((fa, b)) => b
     })
 
     sum.runAsync

--- a/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
+++ b/monix-eval/shared/src/test/scala/monix/eval/TaskGatherUnorderedSuite.scala
@@ -17,8 +17,9 @@
 
 package monix.eval
 
-import concurrent.duration._
-import scala.util.{Success, Failure}
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
 
 object TaskGatherUnorderedSuite extends BaseTestSuite {
   test("Task.gatherUnordered should execute in parallel") { implicit s =>
@@ -63,7 +64,17 @@ object TaskGatherUnorderedSuite extends BaseTestSuite {
     assertEquals(f.value, None)
   }
 
-  test("Task.gatherUnordered should be stack-safe") { implicit s =>
+  test("Task.gatherUnordered should run over an iterator") { implicit s =>
+    val count = 10
+    val seq = 0 until count
+    val it = seq.iterator.map(x => Task.evalAlways(x + 1))
+    val sum = Task.gatherUnordered(it).map(_.sum)
+
+    val result = sum.runAsync; s.tick()
+    assertEquals(result.value.get, Success((count+1) * count / 2))
+  }
+
+  test("Task.gatherUnordered should be stack-safe on handling many tasks") { implicit s =>
     val count = 10000
     val tasks = (0 until count).map(x => Task.evalAlways(x))
     val sum = Task.gatherUnordered(tasks).map(_.sum)
@@ -72,13 +83,37 @@ object TaskGatherUnorderedSuite extends BaseTestSuite {
     assertEquals(result.value.get, Success(count * (count-1) / 2))
   }
 
-  test("Task.gatherUnordered should run over an iterator") { implicit s =>
-    val count = 10
-    val seq = (0 until count).toSeq
-    val it = seq.iterator.map(x => Task.evalAlways(x + 1))
-    val sum = Task.gatherUnordered(it).map(_.sum)
+  test("Task.gatherUnordered should be stack safe on success") { implicit s =>
+    def fold[A,B](ta: Task[ListBuffer[A]], tb: Task[A]): Task[ListBuffer[A]] =
+      Task.gatherUnordered(List(ta, tb)).map {
+        case a :: b :: Nil =>
+          val (accR, valueR) = if (a.isInstanceOf[ListBuffer[_]]) (a,b) else (b,a)
+          val acc = accR.asInstanceOf[ListBuffer[A]]
+          val value = valueR.asInstanceOf[A]
+          acc += value
+        case _ =>
+          throw new RuntimeException("Oops!")
+      }
 
-    val result = sum.runAsync; s.tick()
-    assertEquals(result.value.get, Success((count+1) * count / 2))
+    def gatherSpecial[A](in: Seq[Task[A]]): Task[List[A]] = {
+      val init = Task.evalAlways(ListBuffer.empty[A])
+      val r = in.foldLeft(init)(fold)
+      r.map(_.result())
+    }
+
+    val count = 100000
+    val tasks = (0 until count).map(n => Task.evalAlways(n))
+    var result = Option.empty[Try[Int]]
+
+    gatherSpecial(tasks).map(_.sum).runAsync(
+      new Callback[Int] {
+        def onSuccess(value: Int): Unit =
+          result = Some(Success(value))
+        def onError(ex: Throwable): Unit =
+          result = Some(Failure(ex))
+      })
+
+    s.tick()
+    assertEquals(result, Some(Success(count * (count - 1) / 2)))
   }
 }

--- a/monix-execution/shared/src/test/scala/monix/execution/cancelables/CompositeCancelableSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/cancelables/CompositeCancelableSuite.scala
@@ -18,9 +18,12 @@
 package monix.execution.cancelables
 
 import minitest.SimpleTestSuite
+import minitest.laws.Checkers
+import monix.execution.Cancelable
+import scala.collection.mutable.ListBuffer
 
-object CompositeCancelableSuite extends SimpleTestSuite {
-  test("cancel") {
+object CompositeCancelableSuite extends SimpleTestSuite with Checkers {
+  test("simple cancel") {
     val s = CompositeCancelable()
     val b1 = BooleanCancelable()
     val b2 = BooleanCancelable()
@@ -45,5 +48,61 @@ object CompositeCancelableSuite extends SimpleTestSuite {
     assert(s.isCanceled)
     assert(b1.isCanceled)
     assert(b2.isCanceled)
+  }
+
+  test("addAll should be equivalent with repeated add") {
+    check2 { (numbers: List[Int], preCancel: Boolean) =>
+      val s1 = CompositeCancelable()
+      if (preCancel) s1.cancel()
+
+      val r1 = ListBuffer.empty[Int]
+      s1 ++= numbers.map(n => Cancelable(() => r1 += n))
+
+      val s2 = CompositeCancelable()
+      if (preCancel) s2.cancel()
+
+      val r2 = ListBuffer.empty[Int]
+      for (n <- numbers) s2 += Cancelable(() => r2 += n)
+
+      if (!preCancel) s1.cancel()
+      if (!preCancel) s2.cancel()
+
+      r1.toList.sorted == r2.toList.sorted
+    }
+  }
+
+  test("addAll should cancel everything after composite is canceled") {
+    val s = CompositeCancelable()
+    s.cancel()
+
+    val seq = (0 until 10).map(_ => BooleanCancelable())
+    s ++= seq
+
+    for (c <- seq) assert(c.isCanceled, "c.isCanceled")
+  }
+
+  test("removeAll should be equivalent with repeated remove") {
+    check2 { (numbers: List[Int], preCancel: Boolean) =>
+      val s1 = CompositeCancelable()
+      if (preCancel) s1.cancel()
+
+      val r1 = ListBuffer.empty[Int]
+      val c1 = numbers.map(n => (n, Cancelable(() => r1 += n)))
+      s1 ++= c1.map(_._2)
+      s1 --= c1.filter(_._1 % 2 == 0).map(_._2)
+
+      val s2 = CompositeCancelable()
+      if (preCancel) s2.cancel()
+
+      val r2 = ListBuffer.empty[Int]
+      val c2 = numbers.map(n => (n, Cancelable(() => r2 += n)))
+      s2 ++= c2.map(_._2)
+      c2.filter(_._1 % 2 == 0).foreach(s2 -= _._2)
+
+      if (!preCancel) s1.cancel()
+      if (!preCancel) s2.cancel()
+
+      r1.toList.sorted == r2.toList.sorted
+    }
   }
 }


### PR DESCRIPTION
Fixes and optimizes `gatherUnordered`. 

The `gatherUnordered` is not stack-safe in its `onSuccess` handling. It's really a corner case, but significant in that no `Task` operation should be stack unsafe.

As for the optimization, adding subscriptions to our`CompositeCancelable` one by one is inneficient because  needs these two ops:

- `addAll(that: TranversableOnce[Cancelable])`
- `removeAll(that: TranversableOnce[Cancelable])`

This is because in case we want to add a whole list of cancelables to a composite, adding them one by one generates `compareAndSet` calls on its internal atomic state for each and every reference added, which is very wasteful. `Task.gatherUnordered` now uses the new `addAll` operation.

I also introduced a benchmark. The results are quite revealing:

```
[info] Benchmark                        Mode  Cnt    Score    Error  Units
[info] TaskGatherBenchmark.gatherA     thrpt   10  107.381 ±  2.937  ops/s
[info] TaskGatherBenchmark.gatherS     thrpt   10   96.838 ±  3.303  ops/s
[info] TaskGatherBenchmark.sequenceA   thrpt   10  220.651 ±  9.420  ops/s
[info] TaskGatherBenchmark.sequenceS   thrpt   10  615.164 ± 14.341  ops/s
[info] TaskGatherBenchmark.unorderedA  thrpt   10  153.785 ± 13.647  ops/s
[info] TaskGatherBenchmark.unorderedS  thrpt   10  383.674 ± 28.970  ops/s
```

In other words `gatherUnordered` is dramatically better than `gather`, having an increase in throughput between 50% and 300%. And `sequence` is better than both, but that was to be expected for the cheap tasks that we are using.