### PR TITLE
Change overflow-strategy onOverflow handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,6 +106,9 @@ lazy val sharedSettings = warnUnusedImport ++ Seq(
     Resolver.sonatypeRepo("releases")
   ),
 
+  // https://github.com/sbt/sbt/issues/2654
+  incOptions := incOptions.value.withLogRecompileOnMacro(false),
+
   // -- Settings meant for deployment on oss.sonatype.org
 
   useGpg := true,
@@ -260,9 +263,7 @@ lazy val typesJS = project.in(file("monix-types/js"))
   .settings(scalaJSSettings)
 
 lazy val executionCommon = crossVersionSharedSources ++ Seq(
-  name := "monix-execution",
-  // https://github.com/sbt/sbt/issues/2654
-  incOptions := incOptions.value.withLogRecompileOnMacro(false)
+  name := "monix-execution"
 )
 
 lazy val executionJVM = project.in(file("monix-execution/jvm"))

--- a/monix-reactive/jvm/src/test/scala/monix/reactive/observers/BufferDropNewAndSignalConcurrencySuite.scala
+++ b/monix-reactive/jvm/src/test/scala/monix/reactive/observers/BufferDropNewAndSignalConcurrencySuite.scala
@@ -37,18 +37,18 @@ object BufferDropNewAndSignalConcurrencySuite
   }
 
   def buildNewForInt(bufferSize: Int, underlying: Observer[Int])(implicit s: Scheduler) = {
-    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => nr.toInt))
+    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Some(nr.toInt)))
   }
 
   def buildNewForLong(bufferSize: Int, underlying: Observer[Long])(implicit s: Scheduler) = {
-    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => nr))
+    BufferedSubscriber(Subscriber(underlying, s), DropNewAndSignal(bufferSize, nr => Some(nr)))
   }
 
   test("merge test should work") { implicit s =>
     val num = 100000
     val source = Observable.repeat(1L).take(num)
     val f = Observable.fromIterable(Seq(source, source, source))
-      .mergeMap(x => x)(DropNewAndSignal(1000, dropped => dropped))
+      .mergeMap(x => x)(DropNewAndSignal(1000, dropped => Some(dropped)))
       .sumF
       .runAsyncGetFirst
 

--- a/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/OverflowStrategy.scala
@@ -90,13 +90,20 @@ object OverflowStrategy {
     * the pipeline should begin dropping incoming events until the buffer
     * has room in it again and is free to process more elements.
     *
+    * The given `onOverflow` function get be used for logging the event
+    * and for sending a message to the downstream consumers to inform
+    * them of dropped messages. The function can return `None` in which
+    * case no message is sent and thus you can use it just to log a warning.
+    *
     * @param bufferSize specifies how many events our buffer can hold
     *        before overflowing.
+    *
     * @param onOverflow is a function that can get called on overflow with
     *        a number of messages that were dropped, a function that builds
-    *        a new message that will be sent to downstream.
+    *        a new message that will be sent to downstream. If it returns
+    *        `None`, then no message gets sent to downstream.
     */
-  final case class DropNewAndSignal[A](bufferSize: Int, onOverflow: Long => A)
+  final case class DropNewAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
     extends Evicted[A] {
 
     require(bufferSize > 1, "bufferSize should be strictly greater than 1")
@@ -119,13 +126,20 @@ object OverflowStrategy {
     * the currently buffered events should start being dropped in a FIFO order,
     * so the oldest events from the buffer will be dropped first.
     *
+    * The given `onOverflow` function get be used for logging the event
+    * and for sending a message to the downstream consumers to inform
+    * them of dropped messages. The function can return `None` in which
+    * case no message is sent and thus you can use it just to log a warning.
+    *
     * @param bufferSize specifies how many events our buffer can hold
     *        before overflowing
+    *
     * @param onOverflow is a function that can get called on overflow with
     *        a number of messages that were dropped, a function that builds
-    *        a new message that will be sent to downstream.
+    *        a new message that will be sent to downstream. If it returns
+    *        `None`, then no message gets sent to downstream.
     */
-  final case class DropOldAndSignal[A](bufferSize: Int, onOverflow: Long => A)
+  final case class DropOldAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
     extends Evicted[A] {
 
     require(bufferSize > 1, "bufferSize should be strictly greater than 1")
@@ -148,18 +162,23 @@ object OverflowStrategy {
     * the current buffer should be dropped completely to make room for
     * new events.
     *
+    * The given `onOverflow` function get be used for logging the event
+    * and for sending a message to the downstream consumers to inform
+    * them of dropped messages. The function can return `None` in which
+    * case no message is sent and thus you can use it just to log a warning.
+    *
     * @param bufferSize specifies how many events our buffer can hold
     *        before overflowing
+    *
     * @param onOverflow is a function that can get called on overflow with
     *        a number of messages that were dropped, a function that builds
     *        a new message that will be sent to downstream.
     */
-  final case class ClearBufferAndSignal[A](bufferSize: Int, onOverflow: Long => A)
+  final case class ClearBufferAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
     extends Evicted[A] {
 
     require(bufferSize > 1, "bufferSize should be strictly greater than 1")
   }
-
 
   /** A category of [[OverflowStrategy]] for buffers that can be used
     * synchronously, without worrying about back-pressure concerns.

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropAllSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropAllSuite.scala
@@ -298,7 +298,7 @@ object BufferDropAllSuite extends TestSuite[TestScheduler] {
     var received = 0L
     var wasCompleted = false
 
-    val buffer = buildNew(Platform.recommendedBatchSize * 3, new Observer[Int] {
+    val buffer = buildNewWithSignal(Platform.recommendedBatchSize * 3, new Observer[Int] {
       def onNext(elem: Int) = {
         received += 1
         Continue

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropNewSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropNewSuite.scala
@@ -312,7 +312,7 @@ object BufferDropNewSuite extends TestSuite[TestScheduler] {
     var received = 0L
     var wasCompleted = false
 
-    val buffer = buildNew(Platform.recommendedBatchSize * 3, new Observer[Int] {
+    val buffer = buildNewWithSignal(Platform.recommendedBatchSize * 3, new Observer[Int] {
       def onNext(elem: Int) = {
         received += 1
         Continue


### PR DESCRIPTION
Changing the signature of the `onOverflow` function parameter given to `DropNewAndSignal`, `DropOldAndSignal` and `ClearBufferAndSignal`.

We have had a signature like this:

```scala
case class DropNewAndSignal[A](bufferSize: Int, onOverflow: Long => A)
  extends OverflowStrategy[A]
```

The `onOverflow` is a function that receives the number of elements that were dropped while the consumer gets busy. So the consumer can then be notified that it had dropped events and behave accordingly. However this isn't always helpful. There are cases where we don't want to send any such message to the consumer, but we just want to log this information somewhere. We can do this currently, but it is way too hard and wasteful (e.g. boxing stuff in `Either` and filtering), so we are changing that signature to this:

```scala
case class DropNewAndSignal[A](bufferSize: Int, onOverflow: Long => Option[A])
  extends OverflowStrategy[A]
```

Thus, you can return `Some(a)` in case you want to inform the downstream subscribers of the overflow, or you can return a `None`, in which case no message gets sent. So you can just return `None` and log stuff.