### PR TITLE
Reset overflow counter on None onOverflow result

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,6 @@ https://github.com/aoprisan
 
 Jisoo Park
 https://github.com/guersam
+
+Dawid Dworak
+https://github.com/ddworak

--- a/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
+++ b/monix-reactive/js/src/main/scala/monix/reactive/observers/buffers/SyncBufferedSubscriber.scala
@@ -112,6 +112,7 @@ private[buffers] final class SyncBufferedSubscriber[-T] private
                 eventsDropped = 0
                 message.asInstanceOf[AnyRef]
               case None =>
+                eventsDropped = 0
                 buffer.poll()
             }
           } catch {

--- a/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
+++ b/monix-reactive/jvm/src/main/scala/monix/reactive/observers/buffers/EvictingBufferedSubscriber.scala
@@ -100,6 +100,7 @@ private[buffers] final class EvictingBufferedSubscriber[-T] private
                 consumerBuffer(0) = message.asInstanceOf[AnyRef]
                 1 + buffer.pollMany(consumerBuffer, 1)
               case None =>
+                eventsDropped = 0
                 buffer.pollMany(consumerBuffer)
             }
           } catch {

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropNewAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropNewAndSignalSuite.scala
@@ -160,7 +160,7 @@ object BufferDropNewAndSignalSuite extends TestSuite[TestScheduler] {
     assert(wasCompleted, "wasCompleted should be true")
   }
 
-  test("should drop incoming when over capacity and log") { implicit s =>
+  test("should drop incoming when over capacity and log once") { implicit s =>
     var received = 0
     var wasCompleted = false
     val promise = Promise[Ack]()
@@ -206,6 +206,13 @@ object BufferDropNewAndSignalSuite extends TestSuite[TestScheduler] {
     assert(log.get > 0, "log should have happened")
     assert(received >= 45 && received <= 60,
       s"received should be either 45 or 60, but got $received")
+
+    log.set(0)
+    assertEquals(buffer.onNext(42), Continue)
+
+    s.tick()
+
+    assertEquals(log.get, 0)
 
     buffer.onComplete(); s.tick()
     assert(wasCompleted, "wasCompleted should be true")

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropOldAndSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropOldAndSignalSuite.scala
@@ -29,7 +29,7 @@ import monix.reactive.exceptions.DummyException
 
 import scala.concurrent.{Future, Promise}
 
-object BufferDropOldThenSignalSuite extends TestSuite[TestScheduler] {
+object BufferDropOldAndSignalSuite extends TestSuite[TestScheduler] {
   def setup() = TestScheduler()
   def tearDown(s: TestScheduler) = {
     assert(s.state.get.tasks.isEmpty,

--- a/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropOldThenSignalSuite.scala
+++ b/monix-reactive/shared/src/test/scala/monix/reactive/observers/BufferDropOldThenSignalSuite.scala
@@ -26,6 +26,7 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import monix.reactive.OverflowStrategy.DropOldAndSignal
 import monix.reactive.exceptions.DummyException
+
 import scala.concurrent.{Future, Promise}
 
 object BufferDropOldThenSignalSuite extends TestSuite[TestScheduler] {
@@ -149,7 +150,7 @@ object BufferDropOldThenSignalSuite extends TestSuite[TestScheduler] {
     assert(wasCompleted, "wasCompleted should be true")
   }
 
-  test("should drop old events when over capacity and log") { implicit s =>
+  test("should drop old events when over capacity and log once") { implicit s =>
     var received = 0
     var wasCompleted = false
     val promise = Promise[Ack]()
@@ -181,6 +182,13 @@ object BufferDropOldThenSignalSuite extends TestSuite[TestScheduler] {
     promise.success(Continue); s.tick()
     assertEquals(received, (1094 to 1100).sum + 28)
     assertEquals(log.get, 994)
+
+    log.set(0)
+    assertEquals(buffer.onNext(42), Continue)
+
+    s.tick()
+
+    assertEquals(log.get, 0)
 
     buffer.onComplete(); s.tick()
     assert(wasCompleted, "wasCompleted should be true")


### PR DESCRIPTION
Hey! 
I know that according to the contribution guidelines I should've opened an issue, but this is just a short bugfix. I will be happy to do it in case you decide it's required here.
I believe that current behaviour of Drop*AndSignal wasn't intended and seems to have been introduced just recently. The docs state:
> The function can return `None` in which case no message is sent and thus you can use it just to log a warning.

yet I've noticed that after an overflow the callback is called for each new message.
I've modified the tests to check for this behaviour and proposed a solution.